### PR TITLE
Replaced Earsketch with HTML workshop

### DIFF
--- a/workshops.html
+++ b/workshops.html
@@ -107,9 +107,10 @@
       </div>
       <a id="link4"></a>
       <div class="jumbotron">
-        <h1 class="display-3">Introduction to Earsketch</h1>
+        <h1 class="display-3">Introduction to HTML</h1>
         <p class="lead">
-          This is a beginner workshop for students who have limited coding knowledge. Students will explore how to use Earsketch, an education program created with the intent of furthering knowledge of Python and Javascript and by creating music.  
+          This is a beginner workshop for students who have limited coding knowledge. Students will
+          explore HTML and learn how to create a basic website. 
         </p>
       </div>
 


### PR DESCRIPTION
On the workshop page, Earsketch has been removed in place of HTML